### PR TITLE
Add game menu system with main menu and pause functionality

### DIFF
--- a/game/ui/main_menu.py
+++ b/game/ui/main_menu.py
@@ -1,0 +1,212 @@
+import pygame
+from typing import Callable, Dict, Optional
+from enum import Enum
+
+
+class MenuOption(Enum):
+    NEW_GAME = "new_game"
+    LOAD_GAME = "load_game"
+    SAVE_GAME = "save_game"
+    OPTIONS = "options"
+    RESUME = "resume"
+    QUIT = "quit"
+
+
+class MainMenu:
+    def __init__(self, screen: pygame.Surface):
+        self.screen = screen
+        self.font = pygame.font.Font(None, 48)
+        self.title_font = pygame.font.Font(None, 96)
+        self.selected_option: Optional[MenuOption] = None
+        self.visible = True
+        
+        self.colors = {
+            'background': (30, 30, 30),
+            'button': (70, 70, 70),
+            'button_hover': (100, 100, 100),
+            'button_disabled': (50, 50, 50),
+            'text': (255, 255, 255),
+            'text_disabled': (128, 128, 128),
+            'border': (200, 200, 200)
+        }
+        
+        self.buttons: Dict[MenuOption, pygame.Rect] = {}
+        self.button_states: Dict[MenuOption, bool] = {
+            MenuOption.NEW_GAME: True,
+            MenuOption.LOAD_GAME: True,
+            MenuOption.SAVE_GAME: False,  # Disabled in main menu
+            MenuOption.OPTIONS: True,
+            MenuOption.RESUME: False,  # Only available in pause menu
+            MenuOption.QUIT: True
+        }
+        
+        self._setup_buttons()
+    
+    def _setup_buttons(self):
+        screen_width, screen_height = self.screen.get_size()
+        button_width = 300
+        button_height = 60
+        button_spacing = 20
+        
+        # Main menu buttons
+        menu_options = [
+            MenuOption.NEW_GAME,
+            MenuOption.LOAD_GAME,
+            MenuOption.OPTIONS,
+            MenuOption.QUIT
+        ]
+        
+        total_height = len(menu_options) * button_height + (len(menu_options) - 1) * button_spacing
+        start_y = (screen_height - total_height) // 2 + 50  # Offset for title
+        
+        for i, option in enumerate(menu_options):
+            x = (screen_width - button_width) // 2
+            y = start_y + i * (button_height + button_spacing)
+            self.buttons[option] = pygame.Rect(x, y, button_width, button_height)
+    
+    def handle_event(self, event: pygame.event.Event) -> Optional[MenuOption]:
+        if not self.visible:
+            return None
+        
+        if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+            mouse_pos = pygame.mouse.get_pos()
+            for option, rect in self.buttons.items():
+                if rect.collidepoint(mouse_pos) and self.button_states[option]:
+                    self.selected_option = option
+                    return option
+        
+        elif event.type == pygame.KEYDOWN:
+            if event.key == pygame.K_ESCAPE:
+                return MenuOption.QUIT
+        
+        return None
+    
+    def draw(self):
+        if not self.visible:
+            return
+        
+        # Draw semi-transparent background
+        overlay = pygame.Surface(self.screen.get_size())
+        overlay.set_alpha(200)
+        overlay.fill(self.colors['background'])
+        self.screen.blit(overlay, (0, 0))
+        
+        # Draw title
+        title_text = self.title_font.render("Castle Knights", True, self.colors['text'])
+        title_rect = title_text.get_rect(center=(self.screen.get_width() // 2, 150))
+        self.screen.blit(title_text, title_rect)
+        
+        # Draw buttons
+        mouse_pos = pygame.mouse.get_pos()
+        
+        for option, rect in self.buttons.items():
+            if not self.button_states[option]:
+                color = self.colors['button_disabled']
+                text_color = self.colors['text_disabled']
+            elif rect.collidepoint(mouse_pos):
+                color = self.colors['button_hover']
+                text_color = self.colors['text']
+            else:
+                color = self.colors['button']
+                text_color = self.colors['text']
+            
+            pygame.draw.rect(self.screen, color, rect)
+            pygame.draw.rect(self.screen, self.colors['border'], rect, 3)
+            
+            # Button text
+            text = self._get_button_text(option)
+            text_surface = self.font.render(text, True, text_color)
+            text_rect = text_surface.get_rect(center=rect.center)
+            self.screen.blit(text_surface, text_rect)
+    
+    def _get_button_text(self, option: MenuOption) -> str:
+        text_map = {
+            MenuOption.NEW_GAME: "New Game",
+            MenuOption.LOAD_GAME: "Load Game",
+            MenuOption.SAVE_GAME: "Save Game",
+            MenuOption.OPTIONS: "Options",
+            MenuOption.RESUME: "Resume",
+            MenuOption.QUIT: "Quit"
+        }
+        return text_map[option]
+    
+    def show(self):
+        self.visible = True
+    
+    def hide(self):
+        self.visible = False
+
+
+class PauseMenu(MainMenu):
+    def __init__(self, screen: pygame.Surface):
+        super().__init__(screen)
+        
+        # Adjust button states for pause menu
+        self.button_states[MenuOption.RESUME] = True
+        self.button_states[MenuOption.SAVE_GAME] = True
+        
+        # Re-setup buttons for pause menu
+        self._setup_pause_buttons()
+    
+    def _setup_pause_buttons(self):
+        screen_width, screen_height = self.screen.get_size()
+        button_width = 300
+        button_height = 60
+        button_spacing = 20
+        
+        # Pause menu buttons
+        menu_options = [
+            MenuOption.RESUME,
+            MenuOption.NEW_GAME,
+            MenuOption.SAVE_GAME,
+            MenuOption.LOAD_GAME,
+            MenuOption.OPTIONS,
+            MenuOption.QUIT
+        ]
+        
+        total_height = len(menu_options) * button_height + (len(menu_options) - 1) * button_spacing
+        start_y = (screen_height - total_height) // 2
+        
+        self.buttons.clear()
+        for i, option in enumerate(menu_options):
+            x = (screen_width - button_width) // 2
+            y = start_y + i * (button_height + button_spacing)
+            self.buttons[option] = pygame.Rect(x, y, button_width, button_height)
+    
+    def draw(self):
+        if not self.visible:
+            return
+        
+        # Draw semi-transparent background
+        overlay = pygame.Surface(self.screen.get_size())
+        overlay.set_alpha(200)
+        overlay.fill(self.colors['background'])
+        self.screen.blit(overlay, (0, 0))
+        
+        # Draw "Paused" title
+        title_text = self.title_font.render("Paused", True, self.colors['text'])
+        title_rect = title_text.get_rect(center=(self.screen.get_width() // 2, 100))
+        self.screen.blit(title_text, title_rect)
+        
+        # Draw buttons
+        mouse_pos = pygame.mouse.get_pos()
+        
+        for option, rect in self.buttons.items():
+            if not self.button_states[option]:
+                color = self.colors['button_disabled']
+                text_color = self.colors['text_disabled']
+            elif rect.collidepoint(mouse_pos):
+                color = self.colors['button_hover']
+                text_color = self.colors['text']
+            else:
+                color = self.colors['button']
+                text_color = self.colors['text']
+            
+            pygame.draw.rect(self.screen, color, rect)
+            pygame.draw.rect(self.screen, self.colors['border'], rect, 3)
+            
+            # Button text
+            text = self._get_button_text(option)
+            text_surface = self.font.render(text, True, text_color)
+            text_rect = text_surface.get_rect(center=rect.center)
+            self.screen.blit(text_surface, text_rect)

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ from game.game_state import GameState
 from game.renderer import Renderer
 from game.input_handler import InputHandler
 from game.ui.battle_setup import BattleSetupScreen
+from game.ui.main_menu import MainMenu, PauseMenu, MenuOption
 
 class Game:
     def __init__(self):
@@ -13,8 +14,16 @@ class Game:
         self.clock = pygame.time.Clock()
         self.running = True
         
+        # Game states
+        self.in_main_menu = True
+        self.in_setup = False
+        self.in_game = False
+        self.paused = False
+        
+        # UI screens
+        self.main_menu = MainMenu(self.screen)
+        self.pause_menu = PauseMenu(self.screen)
         self.battle_setup_screen = BattleSetupScreen(self.screen)
-        self.in_setup = True
         
         self.game_state = None
         self.renderer = Renderer(self.screen)
@@ -24,32 +33,99 @@ class Game:
         while self.running:
             dt = self.clock.tick(60) / 1000.0
             
-            if self.in_setup:
-                for event in pygame.event.get():
-                    if event.type == pygame.QUIT:
-                        self.running = False
-                    else:
-                        self.battle_setup_screen.handle_event(event)
-                
-                if self.battle_setup_screen.ready:
-                    battle_config = self.battle_setup_screen.get_battle_config()
-                    self.game_state = GameState(battle_config)
-                    self.in_setup = False
-                else:
-                    self.battle_setup_screen.draw()
-            else:
-                for event in pygame.event.get():
-                    if event.type == pygame.QUIT:
-                        self.running = False
-                    else:
-                        self.input_handler.handle_event(event, self.game_state)
-                
-                self.game_state.update(dt)
-                self.renderer.render(self.game_state)
-                pygame.display.flip()
+            if self.in_main_menu:
+                self._handle_main_menu()
+            elif self.in_setup:
+                self._handle_battle_setup()
+            elif self.in_game:
+                self._handle_game(dt)
+            
+            pygame.display.flip()
         
         pygame.quit()
         sys.exit()
+    
+    def _handle_main_menu(self):
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                self.running = False
+            else:
+                option = self.main_menu.handle_event(event)
+                if option == MenuOption.NEW_GAME:
+                    self.in_main_menu = False
+                    self.in_setup = True
+                elif option == MenuOption.LOAD_GAME:
+                    # Placeholder for load game functionality
+                    print("Load Game - Not implemented yet")
+                elif option == MenuOption.OPTIONS:
+                    # Placeholder for options menu
+                    print("Options - Not implemented yet")
+                elif option == MenuOption.QUIT:
+                    self.running = False
+        
+        self.screen.fill((0, 0, 0))
+        self.main_menu.draw()
+    
+    def _handle_battle_setup(self):
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                self.running = False
+            elif event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE:
+                # Go back to main menu
+                self.in_setup = False
+                self.in_main_menu = True
+                self.battle_setup_screen.ready = False
+            else:
+                self.battle_setup_screen.handle_event(event)
+        
+        if self.battle_setup_screen.ready:
+            battle_config = self.battle_setup_screen.get_battle_config()
+            self.game_state = GameState(battle_config)
+            self.in_setup = False
+            self.in_game = True
+            self.battle_setup_screen.ready = False
+        else:
+            self.battle_setup_screen.draw()
+    
+    def _handle_game(self, dt):
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                self.running = False
+            elif event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE:
+                # Toggle pause menu
+                self.paused = not self.paused
+                if self.paused:
+                    self.pause_menu.show()
+                else:
+                    self.pause_menu.hide()
+            elif self.paused:
+                option = self.pause_menu.handle_event(event)
+                if option == MenuOption.RESUME:
+                    self.paused = False
+                    self.pause_menu.hide()
+                elif option == MenuOption.NEW_GAME:
+                    self.paused = False
+                    self.in_game = False
+                    self.in_setup = True
+                    self.pause_menu.hide()
+                elif option == MenuOption.SAVE_GAME:
+                    print("Save Game - Not implemented yet")
+                elif option == MenuOption.LOAD_GAME:
+                    print("Load Game - Not implemented yet")
+                elif option == MenuOption.OPTIONS:
+                    print("Options - Not implemented yet")
+                elif option == MenuOption.QUIT:
+                    self.running = False
+            else:
+                self.input_handler.handle_event(event, self.game_state)
+        
+        if not self.paused:
+            self.game_state.update(dt)
+        
+        self.renderer.render(self.game_state)
+        
+        if self.paused:
+            self.pause_menu.draw()
 
 if __name__ == "__main__":
     game = Game()

--- a/tests/test_menu_system.py
+++ b/tests/test_menu_system.py
@@ -1,0 +1,136 @@
+import unittest
+import pygame
+from game.ui.main_menu import MainMenu, PauseMenu, MenuOption
+
+
+class TestMenuSystem(unittest.TestCase):
+    def setUp(self):
+        pygame.init()
+        self.screen = pygame.display.set_mode((1024, 768))
+    
+    def tearDown(self):
+        pygame.quit()
+    
+    def test_main_menu_creation(self):
+        """Test main menu initializes correctly"""
+        menu = MainMenu(self.screen)
+        
+        # Check initial state
+        self.assertTrue(menu.visible)
+        self.assertIsNone(menu.selected_option)
+        
+        # Check buttons are created
+        self.assertIn(MenuOption.NEW_GAME, menu.buttons)
+        self.assertIn(MenuOption.LOAD_GAME, menu.buttons)
+        self.assertIn(MenuOption.OPTIONS, menu.buttons)
+        self.assertIn(MenuOption.QUIT, menu.buttons)
+        
+        # Check button states
+        self.assertTrue(menu.button_states[MenuOption.NEW_GAME])
+        self.assertTrue(menu.button_states[MenuOption.LOAD_GAME])
+        self.assertTrue(menu.button_states[MenuOption.OPTIONS])
+        self.assertTrue(menu.button_states[MenuOption.QUIT])
+        self.assertFalse(menu.button_states[MenuOption.SAVE_GAME])
+        self.assertFalse(menu.button_states[MenuOption.RESUME])
+    
+    def test_pause_menu_creation(self):
+        """Test pause menu has different button configuration"""
+        menu = PauseMenu(self.screen)
+        
+        # Check pause menu specific buttons
+        self.assertIn(MenuOption.RESUME, menu.buttons)
+        self.assertIn(MenuOption.SAVE_GAME, menu.buttons)
+        
+        # Check button states
+        self.assertTrue(menu.button_states[MenuOption.RESUME])
+        self.assertTrue(menu.button_states[MenuOption.SAVE_GAME])
+    
+    def test_menu_visibility(self):
+        """Test menu show/hide functionality"""
+        menu = MainMenu(self.screen)
+        
+        # Initially visible
+        self.assertTrue(menu.visible)
+        
+        # Test hide
+        menu.hide()
+        self.assertFalse(menu.visible)
+        
+        # Test show
+        menu.show()
+        self.assertTrue(menu.visible)
+    
+    def test_mouse_click_handling(self):
+        """Test menu responds to mouse clicks"""
+        menu = MainMenu(self.screen)
+        
+        # Get the New Game button rect
+        new_game_rect = menu.buttons[MenuOption.NEW_GAME]
+        
+        # Create mouse click event at button center
+        click_event = pygame.event.Event(pygame.MOUSEBUTTONDOWN, {
+            'button': 1,
+            'pos': new_game_rect.center
+        })
+        
+        # Mock pygame.mouse.get_pos to return button center
+        original_get_pos = pygame.mouse.get_pos
+        pygame.mouse.get_pos = lambda: new_game_rect.center
+        
+        try:
+            result = menu.handle_event(click_event)
+            self.assertEqual(result, MenuOption.NEW_GAME)
+            self.assertEqual(menu.selected_option, MenuOption.NEW_GAME)
+        finally:
+            pygame.mouse.get_pos = original_get_pos
+    
+    def test_escape_key_handling(self):
+        """Test menu responds to escape key"""
+        menu = MainMenu(self.screen)
+        
+        # Create escape key event
+        escape_event = pygame.event.Event(pygame.KEYDOWN, {
+            'key': pygame.K_ESCAPE
+        })
+        
+        result = menu.handle_event(escape_event)
+        self.assertEqual(result, MenuOption.QUIT)
+    
+    def test_disabled_button_click(self):
+        """Test clicking disabled button returns None"""
+        menu = PauseMenu(self.screen)
+        
+        # Disable save game button for testing
+        menu.button_states[MenuOption.SAVE_GAME] = False
+        save_rect = menu.buttons[MenuOption.SAVE_GAME]
+        
+        # Create mouse click event at button center
+        click_event = pygame.event.Event(pygame.MOUSEBUTTONDOWN, {
+            'button': 1,
+            'pos': save_rect.center
+        })
+        
+        # Mock pygame.mouse.get_pos
+        original_get_pos = pygame.mouse.get_pos
+        pygame.mouse.get_pos = lambda: save_rect.center
+        
+        try:
+            result = menu.handle_event(click_event)
+            self.assertIsNone(result)
+        finally:
+            pygame.mouse.get_pos = original_get_pos
+    
+    def test_button_text_mapping(self):
+        """Test button text is correctly mapped"""
+        menu = MainMenu(self.screen)
+        
+        self.assertEqual(menu._get_button_text(MenuOption.NEW_GAME), "New Game")
+        self.assertEqual(menu._get_button_text(MenuOption.LOAD_GAME), "Load Game")
+        self.assertEqual(menu._get_button_text(MenuOption.SAVE_GAME), "Save Game")
+        self.assertEqual(menu._get_button_text(MenuOption.OPTIONS), "Options")
+        self.assertEqual(menu._get_button_text(MenuOption.RESUME), "Resume")
+        self.assertEqual(menu._get_button_text(MenuOption.QUIT), "Quit")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- Add main menu with New Game, Load, Options, and Quit buttons
- Add pause menu (ESC key) with Resume, Save, and other options
- Integrate menu flow into game states
- Add placeholder buttons for future Load/Save/Options features
- Add comprehensive menu system tests
- Update game flow to start with main menu
- Allow ESC to return from battle setup to main menu