### PR TITLE
Add ranged attack visuals

### DIFF
--- a/game/game_state.py
+++ b/game/game_state.py
@@ -512,9 +512,11 @@ class GameState(IGameState):
         
         if distance <= attack_range:
             target = self.get_knight_at(tile_x, tile_y)
-            if target and target.player_id != self.current_player:
-                # Use attack behavior if available (which includes terrain-based AP costs and line of sight)
-                if hasattr(self.selected_knight, 'behaviors') and 'attack' in self.selected_knight.behaviors:
+            if not target or target.player_id == self.current_player:
+                return False
+
+            # Use attack behavior if available (which includes terrain-based AP costs and line of sight)
+            if hasattr(self.selected_knight, 'behaviors') and 'attack' in self.selected_knight.behaviors:
                     attack_behavior = self.selected_knight.behaviors['attack']
                     # Check if target is valid (includes line of sight for archers)
                     valid_targets = attack_behavior.get_valid_targets(self.selected_knight, self)

--- a/tests/test_attack_animation.py
+++ b/tests/test_attack_animation.py
@@ -1,0 +1,44 @@
+import unittest
+from game.animation import AttackAnimation
+from game.entities.unit_factory import UnitFactory
+from game.test_utils.mock_game_state import MockGameState
+
+class TestAttackAnimation(unittest.TestCase):
+    def setUp(self):
+        self.game_state = MockGameState(create_terrain=False)
+        self.archer = UnitFactory.create_archer("Archer", 1, 1)
+        self.warrior = UnitFactory.create_warrior("Target", 3, 1)
+
+    def test_ranged_animation_arrow(self):
+        anim = AttackAnimation(self.archer, self.warrior, damage=5)
+        # Start of animation
+        anim.elapsed = 0.0
+        anim.update(0.0)
+        pos_start = anim.get_current_arrow_position()
+        self.assertAlmostEqual(pos_start[0], self.archer.x)
+        self.assertAlmostEqual(pos_start[1], self.archer.y)
+
+        # Midway before hit
+        anim.elapsed = anim.duration * 0.25
+        anim.update(0.0)
+        pos_mid = anim.get_current_arrow_position()
+        self.assertIsNotNone(pos_mid)
+        self.assertGreater(pos_mid[0], self.archer.x)
+        self.assertLess(pos_mid[0], self.warrior.x)
+
+        # After impact
+        anim.elapsed = anim.duration * 0.6
+        anim.update(0.0)
+        self.assertIsNone(anim.get_current_arrow_position())
+
+    def test_melee_animation_no_arrow(self):
+        attacker = UnitFactory.create_warrior("Attacker", 1, 1)
+        target = UnitFactory.create_warrior("Defender", 2, 1)
+        anim = AttackAnimation(attacker, target, damage=5)
+        anim.elapsed = anim.duration * 0.25
+        anim.update(0.0)
+        self.assertFalse(anim.is_ranged)
+        self.assertIsNone(anim.get_current_arrow_position())
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_attack_with_selected_knight_hex.py
+++ b/tests/test_attack_with_selected_knight_hex.py
@@ -1,0 +1,29 @@
+import unittest
+import pygame
+from game.entities.unit_factory import UnitFactory
+from game.game_state import GameState
+
+class TestAttackWithSelectedKnightHex(unittest.TestCase):
+    def setUp(self):
+        pygame.init()
+        self.game_state = GameState(vs_ai=False)
+        self.game_state.knights.clear()
+        self.game_state.current_player = 1
+        self.attacker = UnitFactory.create_warrior("Attacker", 4, 4)
+        self.attacker.player_id = 1
+        self.game_state.knights.append(self.attacker)
+        self.game_state.selected_knight = self.attacker
+
+    def test_returns_false_when_no_target(self):
+        result = self.game_state.attack_with_selected_knight_hex(5, 4)
+        self.assertFalse(result)
+
+    def test_returns_false_when_target_is_friendly(self):
+        friend = UnitFactory.create_warrior("Friend", 5, 4)
+        friend.player_id = 1
+        self.game_state.knights.append(friend)
+        result = self.game_state.attack_with_selected_knight_hex(5, 4)
+        self.assertFalse(result)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- extend `AttackAnimation` with ranged support and progress tracking
- render arrows for ranged attacks and flash on hit
- add unit tests covering ranged and melee attack animations

## Testing
- `pytest tests/test_attack_animation.py -q`
- `pytest tests/test_path_animation.py::TestPathAnimation::test_path_animation_creation -q`
- `pytest tests/test_attack_animation.py tests/test_path_animation.py::TestPathAnimation::test_path_animation_creation -q`

------
https://chatgpt.com/codex/tasks/task_e_683f542264ec83239ec0f281e0fb11ba