### PR TITLE
Fix fog-of-war view for AI turns

### DIFF
--- a/game/game_state.py
+++ b/game/game_state.py
@@ -46,6 +46,11 @@ class GameState(IGameState):
         self.selected_knight = None
         self.possible_moves = []
         self.turn_number = 1
+
+        # Determine which player's perspective to use for fog of war rendering
+        # When playing vs AI we always view from player 1's perspective
+        # In multiplayer mode we view the current player's perspective
+        # This is exposed via the fog_view_player property
         
         self.vs_ai = vs_ai
         self.ai_player = AIPlayer(2, 'medium') if vs_ai else None
@@ -99,6 +104,11 @@ class GameState(IGameState):
         if hasattr(self, 'camera_manager'):
             self.camera_manager.camera_x = self.camera_x
             self.camera_manager.camera_y = self.camera_y
+
+    @property
+    def fog_view_player(self) -> int:
+        """Player id whose vision should be used for rendering."""
+        return 1 if self.vs_ai else self.current_player
     
     def _init_game(self):
         
@@ -868,7 +878,7 @@ class GameState(IGameState):
             if knight.player_id != self.current_player:
                 # Check fog of war visibility
                 if hasattr(self, 'fog_of_war'):
-                    visibility = self.fog_of_war.get_visibility_state(self.current_player, knight.x, knight.y)
+                    visibility = self.fog_of_war.get_visibility_state(self.fog_view_player, knight.x, knight.y)
                     if visibility != VisibilityState.VISIBLE:
                         continue  # Skip invisible units
                 
@@ -900,7 +910,7 @@ class GameState(IGameState):
                     not knight.is_garrisoned):
                     # Check fog of war visibility
                     if hasattr(self, 'fog_of_war'):
-                        visibility = self.fog_of_war.get_visibility_state(self.current_player, knight.x, knight.y)
+                        visibility = self.fog_of_war.get_visibility_state(self.fog_view_player, knight.x, knight.y)
                         if visibility != VisibilityState.VISIBLE:
                             continue  # Skip invisible units
                     
@@ -928,7 +938,7 @@ class GameState(IGameState):
         
         # Check fog of war visibility
         if hasattr(self, 'fog_of_war'):
-            visibility = self.fog_of_war.get_visibility_state(self.current_player, tile_x, tile_y)
+            visibility = self.fog_of_war.get_visibility_state(self.fog_view_player, tile_x, tile_y)
             if visibility != VisibilityState.VISIBLE:
                 return {
                     'can_charge': False,

--- a/game/renderer_old.py
+++ b/game/renderer_old.py
@@ -194,8 +194,8 @@ class Renderer:
                 
                 # Check fog of war visibility and apply overlay
                 visibility = VisibilityState.VISIBLE  # Default for no fog
-                if hasattr(game_state, 'fog_of_war') and game_state.current_player is not None:
-                    visibility = game_state.fog_of_war.get_visibility_state(game_state.current_player, col, row)
+                if hasattr(game_state, 'fog_of_war') and game_state.fog_view_player is not None:
+                    visibility = game_state.fog_of_war.get_visibility_state(game_state.fog_view_player, col, row)
                 
                 # Apply fog overlay for non-visible hexes
                 if visibility != VisibilityState.VISIBLE:
@@ -342,9 +342,9 @@ class Renderer:
         for castle in game_state.castles:
             # Check if any part of the castle is visible
             castle_visible = False
-            if hasattr(game_state, 'fog_of_war') and game_state.current_player is not None:
+            if hasattr(game_state, 'fog_of_war') and game_state.fog_view_player is not None:
                 for tile_x, tile_y in castle.occupied_tiles:
-                    visibility = game_state.fog_of_war.get_visibility_state(game_state.current_player, tile_x, tile_y)
+                    visibility = game_state.fog_of_war.get_visibility_state(game_state.fog_view_player, tile_x, tile_y)
                     if visibility in [VisibilityState.VISIBLE, VisibilityState.PARTIAL, VisibilityState.EXPLORED]:
                         castle_visible = True
                         break
@@ -419,8 +419,8 @@ class Renderer:
         for knight in game_state.knights:
             # Check fog of war visibility
             is_identified = True  # Default to identified if no fog of war
-            if hasattr(game_state, 'fog_of_war') and game_state.current_player is not None:
-                visibility = game_state.fog_of_war.get_visibility_state(game_state.current_player, knight.x, knight.y)
+            if hasattr(game_state, 'fog_of_war') and game_state.fog_view_player is not None:
+                visibility = game_state.fog_of_war.get_visibility_state(game_state.fog_view_player, knight.x, knight.y)
                 
                 # Don't draw units we can't see
                 if visibility not in [VisibilityState.VISIBLE, VisibilityState.PARTIAL]:

--- a/game/rendering/terrain_renderer.py
+++ b/game/rendering/terrain_renderer.py
@@ -185,8 +185,8 @@ class TerrainRenderer:
         """Apply fog of war overlay based on visibility state."""
         # Check fog of war visibility
         visibility = VisibilityState.VISIBLE  # Default for no fog
-        if hasattr(game_state, 'fog_of_war') and game_state.current_player is not None:
-            visibility = game_state.fog_of_war.get_visibility_state(game_state.current_player, col, row)
+        if hasattr(game_state, 'fog_of_war') and game_state.fog_view_player is not None:
+            visibility = game_state.fog_of_war.get_visibility_state(game_state.fog_view_player, col, row)
         
         # Apply fog overlay for non-visible hexes
         if visibility != VisibilityState.VISIBLE:

--- a/game/rendering/unit_renderer.py
+++ b/game/rendering/unit_renderer.py
@@ -52,20 +52,20 @@ class UnitRenderer:
     
     def _should_render_unit(self, unit, game_state) -> bool:
         """Check if unit should be rendered based on fog of war."""
-        if not hasattr(game_state, 'fog_of_war') or game_state.current_player is None:
+        if not hasattr(game_state, 'fog_of_war') or game_state.fog_view_player is None:
             return True
-        
-        visibility = game_state.fog_of_war.get_visibility_state(game_state.current_player, unit.x, unit.y)
+
+        visibility = game_state.fog_of_war.get_visibility_state(game_state.fog_view_player, unit.x, unit.y)
         return visibility in [VisibilityState.VISIBLE, VisibilityState.PARTIAL]
     
     def _should_render_castle(self, castle, game_state) -> bool:
         """Check if castle should be rendered based on fog of war."""
-        if not hasattr(game_state, 'fog_of_war') or game_state.current_player is None:
+        if not hasattr(game_state, 'fog_of_war') or game_state.fog_view_player is None:
             return True
         
         # Check if any castle tile is visible
         for tile_x, tile_y in castle.occupied_tiles:
-            visibility = game_state.fog_of_war.get_visibility_state(game_state.current_player, tile_x, tile_y)
+            visibility = game_state.fog_of_war.get_visibility_state(game_state.fog_view_player, tile_x, tile_y)
             if visibility in [VisibilityState.VISIBLE, VisibilityState.PARTIAL]:
                 return True
         return False
@@ -113,11 +113,11 @@ class UnitRenderer:
     
     def _is_unit_identified(self, unit, game_state) -> bool:
         """Check if unit is fully identified (not just detected)."""
-        if not hasattr(game_state, 'fog_of_war') or game_state.current_player is None:
+        if not hasattr(game_state, 'fog_of_war') or game_state.fog_view_player is None:
             return True
-        
-        visibility = game_state.fog_of_war.get_visibility_state(game_state.current_player, unit.x, unit.y)
-        return (visibility == VisibilityState.VISIBLE or unit.player_id == game_state.current_player)
+
+        visibility = game_state.fog_of_war.get_visibility_state(game_state.fog_view_player, unit.x, unit.y)
+        return (visibility == VisibilityState.VISIBLE or unit.player_id == game_state.fog_view_player)
     
     def _render_unit_sprite(self, unit, screen_x: float, screen_y: float, is_identified: bool):
         """Render the unit sprite based on type and identification status."""


### PR DESCRIPTION
## Summary
- adjust fog-of-war to remain from player one's perspective when playing vs AI
- add `fog_view_player` property to `GameState`
- use `fog_view_player` for renderers and targeting checks

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError for game.renderer and others)*

------
https://chatgpt.com/codex/tasks/task_e_683f5d8607208323aee0b4c9bd5b7183