### PR TITLE
Add cavalry screening scenario

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Terrain blocking uses existing fog of war line-of-sight calculations
   - Clear user feedback when shots are blocked by terrain
   - Added test scenario for archer line-of-sight mechanics
+  - Added test scenario for cavalry screening mechanics
 - Comprehensive game documentation system
   - Created docs/ folder with detailed mechanism guides
   - Complete routing system documentation with tactical implications

--- a/game/test_scenarios.py
+++ b/game/test_scenarios.py
@@ -23,6 +23,7 @@ class ScenarioType(Enum):
     JSON_ARCHER_MECHANICS = "JSON: Archer Mechanics Test"
     JSON_CAVALRY_CHARGE = "JSON: Cavalry Charge Test"
     JSON_FOG_OF_WAR = "JSON: Fog of War Test"
+    JSON_CAVALRY_SCREENING = "JSON: Cavalry Screening Test"
 
 class TestScenario:
     """Base class for test scenarios
@@ -316,7 +317,8 @@ class TestScenarios:
         json_scenarios = {
             ScenarioType.JSON_ARCHER_MECHANICS: 'archer_mechanics.json',
             ScenarioType.JSON_CAVALRY_CHARGE: 'cavalry_charge.json',
-            ScenarioType.JSON_FOG_OF_WAR: 'fog_of_war.json'
+            ScenarioType.JSON_FOG_OF_WAR: 'fog_of_war.json',
+            ScenarioType.JSON_CAVALRY_SCREENING: 'cavalry_screening.json'
         }
         
         for scenario_type, filename in json_scenarios.items():

--- a/test_scenarios/README.md
+++ b/test_scenarios/README.md
@@ -104,6 +104,8 @@ Tests archer ranged attacks and positioning. Includes hills for elevation testin
 
 ### cavalry_charge.json
 Tests cavalry charge mechanics against different unit types and on various terrain.
+### cavalry_screening.json
+Scenario for experimenting with cavalry screening mechanics.
 
 ### fog_of_war.json
 Tests visibility mechanics with terrain obstacles and unit positioning.

--- a/test_scenarios/cavalry_screening.json
+++ b/test_scenarios/cavalry_screening.json
@@ -1,0 +1,20 @@
+{
+  "name": "Cavalry Screening Test",
+  "description": "Scenario to test the upcoming cavalry screening mechanic",
+  "board_size": [20, 15],
+  "terrain": {
+    "base": "plains",
+    "tiles": []
+  },
+  "units": [
+    {"name": "Screening Cavalry", "type": "cavalry", "x": 7, "y": 8, "player": 1, "facing": "EAST"},
+    {"name": "Protected Archer", "type": "archer", "x": 6, "y": 8, "player": 1, "facing": "EAST"},
+    {"name": "Enemy Warrior", "type": "warrior", "x": 10, "y": 8, "player": 2, "facing": "WEST"},
+    {"name": "Enemy Archer", "type": "archer", "x": 12, "y": 8, "player": 2, "facing": "WEST"}
+  ],
+  "castles": [],
+  "victory_conditions": {
+    "type": "custom",
+    "description": "Move the cavalry to screen the archer from enemy attacks. Use this to experiment with screening once implemented."
+  }
+}


### PR DESCRIPTION
## Summary
- add new `cavalry_screening.json` scenario
- document the scenario in the JSON README
- load the new scenario via `TestScenarios`
- note scenario addition in CHANGELOG

## Testing
- `pip install pygame`
- `python -m pytest -q` *(interrupted after ~78s)*

------
https://chatgpt.com/codex/tasks/task_e_6840709fd4bc8323911671d1b62d82fb