### PR TITLE
Remove unused pointy hex layout

### DIFF
--- a/game/game_state.py
+++ b/game/game_state.py
@@ -74,7 +74,7 @@ class GameState(IGameState):
         
         # Hex layout for coordinate conversions
         from game.hex_layout import HexLayout
-        self.hex_layout = HexLayout(hex_size=36, orientation='flat')
+        self.hex_layout = HexLayout(hex_size=36)
         
         # Legacy message properties for compatibility (will be removed)
         self.messages = []
@@ -1011,7 +1011,7 @@ class GameState(IGameState):
             
             if self.hex_layout.hex_size != expected_hex_size:
                 from game.hex_layout import HexLayout
-                self.hex_layout = HexLayout(hex_size=expected_hex_size, orientation='flat')
+                self.hex_layout = HexLayout(hex_size=expected_hex_size)
 
                 # Adjust camera bounds so the board remains fully reachable
                 hl = self.hex_layout

--- a/game/hex_layout.py
+++ b/game/hex_layout.py
@@ -9,50 +9,34 @@ from game.hex_utils import HexCoord, HexGrid
 
 
 class HexLayout:
-    """Manages hex positioning and layout calculations"""
-    
-    def __init__(self, hex_size: float = 36, orientation: str = 'flat'):
-        """
-        Initialize hex layout.
-        
+    """Manages hex positioning and layout calculations for a flat-top grid."""
+
+    def __init__(self, hex_size: float = 36):
+        """Initialize hex layout for a flat-top hex grid.
+
         Args:
-            hex_size: Distance from center to any corner
-            orientation: 'flat' for flat-top or 'pointy' for pointy-top
+            hex_size: Distance from center to any corner.
         """
         self.hex_size = hex_size
-        self.orientation = orientation
-        
-        if orientation == 'flat':
-            # Flat-top hexagon measurements
-            # Width is the distance between flat sides (horizontal)
-            self.hex_width = math.sqrt(3) * hex_size
-            # Height is the distance between points (vertical)
-            self.hex_height = 2 * hex_size
-            
-            # For proper interlocking:
-            # - Horizontal spacing between hex centers in same row = sqrt(3) * hex_size
-            # - Vertical spacing between rows = 3/2 * hex_size
-            # - Odd rows offset by half the column spacing
-            self.col_spacing = math.sqrt(3) * hex_size  # Distance between centers
-            self.row_spacing = 1.5 * hex_size  # 3/4 of height
-            self.row_offset = self.col_spacing / 2  # Half column spacing for odd rows
-        else:
-            # Pointy-top hexagon measurements
-            self.hex_width = math.sqrt(3) * hex_size
-            self.hex_height = 2 * hex_size
-            
-            # For pointy-top:
-            # - Horizontal spacing = hex_width
-            # - Vertical spacing = 3/2 * hex_size
-            # - Odd columns offset by hex_height / 2
-            self.col_spacing = self.hex_width
-            self.row_spacing = 1.5 * hex_size
-            self.row_offset = self.hex_height / 2
+
+        # Flat-top hexagon measurements
+        # Width is the distance between flat sides (horizontal)
+        self.hex_width = math.sqrt(3) * hex_size
+        # Height is the distance between points (vertical)
+        self.hex_height = 2 * hex_size
+
+        # For proper interlocking:
+        # - Horizontal spacing between hex centers in same row = sqrt(3) * hex_size
+        # - Vertical spacing between rows = 3/2 * hex_size
+        # - Odd rows offset by half the column spacing
+        self.col_spacing = math.sqrt(3) * hex_size  # Distance between centers
+        self.row_spacing = 1.5 * hex_size  # 3/4 of height
+        self.row_offset = self.col_spacing / 2  # Half column spacing for odd rows
     
     def hex_to_pixel(self, col: int, row: int) -> Tuple[float, float]:
         """
         Convert hex grid coordinates to pixel position (center of hex).
-        Uses offset coordinates (odd-r for flat-top, odd-q for pointy-top).
+        Uses odd-r offset coordinates for a flat-top grid.
         
         Args:
             col: Column in hex grid
@@ -61,22 +45,13 @@ class HexLayout:
         Returns:
             (x, y) pixel coordinates of hex center
         """
-        if self.orientation == 'flat':
-            # Flat-top with odd-r offset
-            x = col * self.col_spacing
-            y = row * self.row_spacing
-            
-            # Offset odd rows to the right
-            if row % 2 == 1:
-                x += self.row_offset
-        else:
-            # Pointy-top with odd-q offset
-            x = col * self.col_spacing
-            y = row * self.row_spacing
-            
-            # Offset odd columns down
-            if col % 2 == 1:
-                y += self.row_offset
+        # Flat-top with odd-r offset
+        x = col * self.col_spacing
+        y = row * self.row_spacing
+
+        # Offset odd rows to the right
+        if row % 2 == 1:
+            x += self.row_offset
         
         return (x, y)
     
@@ -91,50 +66,37 @@ class HexLayout:
         Returns:
             (col, row) in hex grid
         """
-        if self.orientation == 'flat':
-            # For flat-top hexes
-            # First approximation
-            row = int(round(y / self.row_spacing))
-            
-            # Adjust x based on row offset
-            adjusted_x = x
-            if row % 2 == 1:
-                adjusted_x -= self.row_offset
-            
-            col = int(round(adjusted_x / self.col_spacing))
-            
-            # Fine-tune using hex distance
-            # Check the 4 nearest hex centers and pick closest
-            candidates = [
-                (col, row),
-                (col - 1, row), (col + 1, row),
-                (col, row - 1), (col, row + 1)
-            ]
-            
-            best_col, best_row = col, row
-            best_dist = float('inf')
-            
-            for c, r in candidates:
-                if c >= 0 and r >= 0:  # Only positive coordinates
-                    hx, hy = self.hex_to_pixel(c, r)
-                    dist = math.sqrt((x - hx)**2 + (y - hy)**2)
-                    if dist < best_dist:
-                        best_dist = dist
-                        best_col, best_row = c, r
-            
-            return (best_col, best_row)
-        else:
-            # For pointy-top hexes
-            col = int(round(x / self.col_spacing))
-            
-            # Adjust y based on column offset
-            adjusted_y = y
-            if col % 2 == 1:
-                adjusted_y -= self.row_offset
-            
-            row = int(round(adjusted_y / self.row_spacing))
-            
-            return (col, row)
+        # For flat-top hexes
+        # First approximation
+        row = int(round(y / self.row_spacing))
+
+        # Adjust x based on row offset
+        adjusted_x = x
+        if row % 2 == 1:
+            adjusted_x -= self.row_offset
+
+        col = int(round(adjusted_x / self.col_spacing))
+
+        # Fine-tune using hex distance
+        # Check the 4 nearest hex centers and pick closest
+        candidates = [
+            (col, row),
+            (col - 1, row), (col + 1, row),
+            (col, row - 1), (col, row + 1)
+        ]
+
+        best_col, best_row = col, row
+        best_dist = float('inf')
+
+        for c, r in candidates:
+            if c >= 0 and r >= 0:  # Only positive coordinates
+                hx, hy = self.hex_to_pixel(c, r)
+                dist = math.sqrt((x - hx)**2 + (y - hy)**2)
+                if dist < best_dist:
+                    best_dist = dist
+                    best_col, best_row = c, r
+
+        return (best_col, best_row)
     
     def get_hex_corners(self, center_x: float, center_y: float) -> list:
         """
@@ -148,13 +110,9 @@ class HexLayout:
             List of (x, y) tuples for each corner
         """
         corners = []
-        
-        if self.orientation == 'flat':
-            # Flat-top hex, first corner at 30 degrees
-            angle_offset = 30
-        else:
-            # Pointy-top hex, first corner at 0 degrees
-            angle_offset = 0
+
+        # Flat-top hex, first corner at 30 degrees
+        angle_offset = 30
         
         for i in range(6):
             angle_deg = 60 * i + angle_offset
@@ -173,45 +131,23 @@ class HexLayout:
         Returns:
             List of (col_diff, row_diff) for each of the 6 neighbors
         """
-        if self.orientation == 'flat':
-            # For flat-top hex with odd-r offset
-            # Even row neighbors
-            even_row = [
-                (1, 0),   # East
-                (0, -1),  # Northeast
-                (-1, -1), # Northwest
-                (-1, 0),  # West
-                (-1, 1),  # Southwest
-                (0, 1)    # Southeast
-            ]
-            # Odd row neighbors (shifted due to offset)
-            odd_row = [
-                (1, 0),   # East
-                (1, -1),  # Northeast
-                (0, -1),  # Northwest
-                (-1, 0),  # West
-                (0, 1),   # Southwest
-                (1, 1)    # Southeast
-            ]
-            return (even_row, odd_row)
-        else:
-            # For pointy-top hex with odd-q offset
-            # Even column neighbors
-            even_col = [
-                (0, -1),  # North
-                (1, -1),  # Northeast
-                (1, 0),   # Southeast
-                (0, 1),   # South
-                (-1, 0),  # Southwest
-                (-1, -1)  # Northwest
-            ]
-            # Odd column neighbors
-            odd_col = [
-                (0, -1),  # North
-                (1, 0),   # Northeast
-                (1, 1),   # Southeast
-                (0, 1),   # South
-                (-1, 1),  # Southwest
-                (-1, 0)   # Northwest
-            ]
-            return (even_col, odd_col)
+        # For flat-top hex with odd-r offset
+        # Even row neighbors
+        even_row = [
+            (1, 0),   # East
+            (0, -1),  # Northeast
+            (-1, -1), # Northwest
+            (-1, 0),  # West
+            (-1, 1),  # Southwest
+            (0, 1)    # Southeast
+        ]
+        # Odd row neighbors (shifted due to offset)
+        odd_row = [
+            (1, 0),   # East
+            (1, -1),  # Northeast
+            (0, -1),  # Northwest
+            (-1, 0),  # West
+            (0, 1),   # Southwest
+            (1, 1)    # Southeast
+        ]
+        return (even_row, odd_row)

--- a/game/input_handler.py
+++ b/game/input_handler.py
@@ -11,7 +11,7 @@ class InputHandler:
         self.camera_drag_start_x = 0
         self.camera_drag_start_y = 0
         self.hex_grid = HexGrid(hex_size=36)  # For hex distance calculations
-        self.hex_layout = HexLayout(hex_size=36, orientation='flat')  # For positioning
+        self.hex_layout = HexLayout(hex_size=36)  # For positioning
         self.zoom_level = 1.0
         self.min_zoom = 0.5
         self.max_zoom = 3.0
@@ -229,7 +229,7 @@ class InputHandler:
         # Scale hex size based on zoom level
         new_hex_size = int(36 * zoom_level)
         self.hex_grid = HexGrid(hex_size=new_hex_size)
-        self.hex_layout = HexLayout(hex_size=new_hex_size, orientation='flat')
+        self.hex_layout = HexLayout(hex_size=new_hex_size)
         
         # Update game_state's hex_layout to ensure coordinate conversion consistency
         if hasattr(game_state, 'hex_layout'):

--- a/game/input_handler_old.py
+++ b/game/input_handler_old.py
@@ -11,7 +11,7 @@ class InputHandler:
         self.camera_drag_start_x = 0
         self.camera_drag_start_y = 0
         self.hex_grid = HexGrid(hex_size=36)  # For hex distance calculations
-        self.hex_layout = HexLayout(hex_size=36, orientation='flat')  # For positioning
+        self.hex_layout = HexLayout(hex_size=36)  # For positioning
         self.zoom_level = 1.0
         self.min_zoom = 0.5
         self.max_zoom = 3.0
@@ -198,7 +198,7 @@ class InputHandler:
         """Update hex grid and layout with new zoom level"""
         new_hex_size = int(36 * self.zoom_level)
         self.hex_grid = HexGrid(hex_size=new_hex_size)
-        self.hex_layout = HexLayout(hex_size=new_hex_size, orientation='flat')
+        self.hex_layout = HexLayout(hex_size=new_hex_size)
         
         # Update renderer's hex grid and layout
         if hasattr(game_state, 'renderer'):

--- a/game/renderer_old.py
+++ b/game/renderer_old.py
@@ -12,7 +12,7 @@ class Renderer:
         self.screen = screen
         self.tile_size = 64
         self.hex_grid = HexGrid(hex_size=36)  # For hex distance calculations
-        self.hex_layout = HexLayout(hex_size=36, orientation='flat')  # For positioning
+        self.hex_layout = HexLayout(hex_size=36)  # For positioning
         self.font = pygame.font.Font(None, 24)
         self.ui_font = pygame.font.Font(None, 32)
         self.asset_manager = AssetManager()

--- a/game/rendering/core_renderer.py
+++ b/game/rendering/core_renderer.py
@@ -21,7 +21,7 @@ class CoreRenderer:
         
         # Initialize hex system
         self.hex_grid = HexGrid(hex_size=36)
-        self.hex_layout = HexLayout(hex_size=36, orientation='flat')
+        self.hex_layout = HexLayout(hex_size=36)
         
         # Initialize specialized renderers
         self.terrain_renderer = TerrainRenderer(screen, self.hex_grid, self.hex_layout)

--- a/test_hex_bounds_calculation.py
+++ b/test_hex_bounds_calculation.py
@@ -12,7 +12,7 @@ board_width, board_height = 20, 15
 hex_size = 36
 
 # Create hex layout and camera
-hex_layout = HexLayout(hex_size=hex_size, orientation='flat')
+hex_layout = HexLayout(hex_size=hex_size)
 camera = CameraManager(screen_width, screen_height)
 
 # Test at different zoom levels
@@ -23,7 +23,7 @@ for zoom in zoom_levels:
     
     # Update hex layout for zoom
     scaled_hex_size = int(36 * zoom)
-    hex_layout = HexLayout(hex_size=scaled_hex_size, orientation='flat')
+    hex_layout = HexLayout(hex_size=scaled_hex_size)
     camera.set_zoom(zoom)
     
     # Position camera at bottom-right to test edge visibility

--- a/test_hex_rendering_bounds.py
+++ b/test_hex_rendering_bounds.py
@@ -39,7 +39,7 @@ class TestHexRenderingBounds(unittest.TestCase):
                 # Create terrain renderer with updated hex layout
                 hex_size = int(36 * zoom)
                 hex_grid = HexGrid(hex_size=hex_size)
-                hex_layout = HexLayout(hex_size=hex_size, orientation='flat')
+                hex_layout = HexLayout(hex_size=hex_size)
                 terrain_renderer = TerrainRenderer(self.screen, hex_grid, hex_layout)
                 
                 # Position camera to see bottom-right corner
@@ -80,7 +80,7 @@ class TestHexRenderingBounds(unittest.TestCase):
         
         # Create terrain renderer
         hex_grid = HexGrid(hex_size=36)
-        hex_layout = HexLayout(hex_size=36, orientation='flat')
+        hex_layout = HexLayout(hex_size=36)
         terrain_renderer = TerrainRenderer(self.screen, hex_grid, hex_layout)
         
         # Calculate visible range

--- a/tests/test_hex_layout.py
+++ b/tests/test_hex_layout.py
@@ -5,7 +5,7 @@ from game.hex_layout import HexLayout
 
 class TestHexLayout(unittest.TestCase):
     def setUp(self):
-        self.layout = HexLayout(hex_size=30, orientation='flat')
+        self.layout = HexLayout(hex_size=30)
     
     def test_hex_dimensions(self):
         """Test that hex dimensions are calculated correctly"""
@@ -141,21 +141,6 @@ class TestHexLayout(unittest.TestCase):
                 dist = math.sqrt((neighbor[0] - center[0])**2 + 
                                (neighbor[1] - center[1])**2)
                 self.assertAlmostEqual(dist, expected_dist, places=5)
-
-
-class TestHexLayoutPointyTop(unittest.TestCase):
-    """Test pointy-top orientation"""
-    
-    def setUp(self):
-        self.layout = HexLayout(hex_size=30, orientation='pointy')
-    
-    def test_pointy_hex_dimensions(self):
-        """Test dimensions for pointy-top hexes"""
-        self.assertAlmostEqual(self.layout.hex_width, 30 * math.sqrt(3))
-        self.assertEqual(self.layout.hex_height, 60)
-        self.assertAlmostEqual(self.layout.col_spacing, 30 * math.sqrt(3))
-        self.assertEqual(self.layout.row_spacing, 45)
-        self.assertEqual(self.layout.row_offset, 30)  # hex_height / 2
 
 
 if __name__ == '__main__':

--- a/tests/test_hex_rendering_zoom.py
+++ b/tests/test_hex_rendering_zoom.py
@@ -22,7 +22,7 @@ class TestHexRenderingZoom(unittest.TestCase):
         
         # Create terrain renderer with initial hex layout
         hex_grid = HexGrid(hex_size=36)
-        hex_layout = HexLayout(hex_size=36, orientation='flat')
+        hex_layout = HexLayout(hex_size=36)
         terrain_renderer = TerrainRenderer(self.screen, hex_grid, hex_layout)
         
         # Test at zoom level 1.0
@@ -53,7 +53,7 @@ class TestHexRenderingZoom(unittest.TestCase):
         self.game_state.camera_manager.zoom_level = 2.0
         # Update hex layout to match zoom
         hex_grid = HexGrid(hex_size=72)  # 36 * 2
-        hex_layout = HexLayout(hex_size=72, orientation='flat')
+        hex_layout = HexLayout(hex_size=72)
         terrain_renderer.hex_grid = hex_grid
         terrain_renderer.hex_layout = hex_layout
         
@@ -71,7 +71,7 @@ class TestHexRenderingZoom(unittest.TestCase):
         self.game_state.camera_manager.zoom_level = 0.5
         # Update hex layout to match zoom
         hex_grid = HexGrid(hex_size=18)  # 36 * 0.5
-        hex_layout = HexLayout(hex_size=18, orientation='flat')
+        hex_layout = HexLayout(hex_size=18)
         terrain_renderer.hex_grid = hex_grid
         terrain_renderer.hex_layout = hex_layout
         
@@ -91,7 +91,7 @@ class TestHexRenderingZoom(unittest.TestCase):
         # Set up hex layout
         hex_size = 36
         hex_grid = HexGrid(hex_size=hex_size)
-        hex_layout = HexLayout(hex_size=hex_size, orientation='flat')
+        hex_layout = HexLayout(hex_size=hex_size)
         terrain_renderer = TerrainRenderer(self.screen, hex_grid, hex_layout)
         
         # Position camera to see right edge of board

--- a/tests/test_hex_visual.py
+++ b/tests/test_hex_visual.py
@@ -16,7 +16,7 @@ def visualize_hex_grid():
     clock = pygame.time.Clock()
     
     # Use HexLayout like the game does
-    hex_layout = HexLayout(hex_size=30, orientation='flat')
+    hex_layout = HexLayout(hex_size=30)
     font = pygame.font.Font(None, 20)
     
     running = True
@@ -73,12 +73,11 @@ def visualize_hex_grid():
 
 def test_hex_neighbor_positions():
     """Test that hex neighbors are positioned correctly"""
-    hex_layout = HexLayout(hex_size=30, orientation='flat')
+    hex_layout = HexLayout(hex_size=30)
     hex_grid = HexGrid(hex_size=30)  # For axial coordinate calculations
     
     print("\nHex dimensions (using HexLayout):")
     print(f"Hex size: {hex_layout.hex_size}")
-    print(f"Orientation: {hex_layout.orientation}")
     
     # Test specific positions using HexLayout
     positions = []


### PR DESCRIPTION
## Summary
- drop pointy-top orientation support
- update call sites to new flat-top-only HexLayout
- prune pointy orientation tests

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'pygame')*

------
https://chatgpt.com/codex/tasks/task_e_68409e64390c832386b1a64cb1e0087e