### PR TITLE
Use strategy pattern for unit rendering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,3 +3,4 @@
 - write end-to-end tests for critical paths
 - use fixtures for setup
 - use factories for data generation
+- after every feature, write tests and run all existing tests

--- a/game/rendering/unit_render_strategies.py
+++ b/game/rendering/unit_render_strategies.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+import pygame
+
+
+class UnitRenderStrategy(ABC):
+    """Interface for rendering different unit types."""
+
+    @abstractmethod
+    def render(self, screen: pygame.Surface, player_color: tuple[int, int, int], center_x: int, center_y: int) -> None:
+        """Render the unit sprite to the screen."""
+        raise NotImplementedError
+
+
+class WarriorRenderStrategy(UnitRenderStrategy):
+    """Render strategy for warriors."""
+
+    def render(self, screen: pygame.Surface, player_color: tuple[int, int, int], center_x: int, center_y: int) -> None:
+        pygame.draw.rect(screen, player_color, (center_x - 20, center_y - 20, 40, 40))
+        pygame.draw.rect(screen, (0, 0, 0), (center_x - 20, center_y - 20, 40, 40), 2)
+
+
+class ArcherRenderStrategy(UnitRenderStrategy):
+    """Render strategy for archers."""
+
+    def render(self, screen: pygame.Surface, player_color: tuple[int, int, int], center_x: int, center_y: int) -> None:
+        pygame.draw.polygon(
+            screen,
+            player_color,
+            [(center_x, center_y - 25), (center_x - 20, center_y + 20), (center_x + 20, center_y + 20)],
+        )
+        pygame.draw.polygon(
+            screen,
+            (0, 0, 0),
+            [(center_x, center_y - 25), (center_x - 20, center_y + 20), (center_x + 20, center_y + 20)],
+            2,
+        )
+
+
+class CavalryRenderStrategy(UnitRenderStrategy):
+    """Render strategy for cavalry."""
+
+    def render(self, screen: pygame.Surface, player_color: tuple[int, int, int], center_x: int, center_y: int) -> None:
+        pygame.draw.ellipse(screen, player_color, (center_x - 25, center_y - 15, 50, 30))
+        pygame.draw.ellipse(screen, (0, 0, 0), (center_x - 25, center_y - 15, 50, 30), 2)
+
+
+class MageRenderStrategy(UnitRenderStrategy):
+    """Render strategy for mages."""
+
+    def render(self, screen: pygame.Surface, player_color: tuple[int, int, int], center_x: int, center_y: int) -> None:
+        pygame.draw.circle(screen, player_color, (center_x, center_y), 22)
+        pygame.draw.circle(screen, (0, 0, 0), (center_x, center_y), 22, 2)

--- a/game/rendering/unit_renderer.py
+++ b/game/rendering/unit_renderer.py
@@ -10,6 +10,13 @@ from game.entities.knight import KnightClass
 from game.hex_layout import HexLayout
 from game.visibility import VisibilityState
 from game.asset_manager import AssetManager
+from .unit_render_strategies import (
+    ArcherRenderStrategy,
+    CavalryRenderStrategy,
+    MageRenderStrategy,
+    UnitRenderStrategy,
+    WarriorRenderStrategy,
+)
 
 
 class UnitRenderer:
@@ -36,6 +43,14 @@ class UnitRenderer:
             'facing_arrow': (255, 255, 255),
             'routing_indicator': (255, 200, 0),
             'disrupted_indicator': (255, 100, 0)
+        }
+
+        # Mapping of unit classes to rendering strategies
+        self.unit_render_strategies: dict[KnightClass, UnitRenderStrategy] = {
+            KnightClass.WARRIOR: WarriorRenderStrategy(),
+            KnightClass.ARCHER: ArcherRenderStrategy(),
+            KnightClass.CAVALRY: CavalryRenderStrategy(),
+            KnightClass.MAGE: MageRenderStrategy(),
         }
     
     def render_units(self, game_state):
@@ -130,24 +145,9 @@ class UnitRenderer:
             pygame.draw.circle(self.screen, (64, 64, 64), (center_x, center_y), 15, 2)
             return
         
-        # Draw specific unit type shapes
-        if unit.unit_class == KnightClass.WARRIOR:
-            pygame.draw.rect(self.screen, player_color, (center_x - 20, center_y - 20, 40, 40))
-            pygame.draw.rect(self.screen, (0, 0, 0), (center_x - 20, center_y - 20, 40, 40), 2)
-        
-        elif unit.unit_class == KnightClass.ARCHER:
-            pygame.draw.polygon(self.screen, player_color,
-                              [(center_x, center_y - 25), (center_x - 20, center_y + 20), (center_x + 20, center_y + 20)])
-            pygame.draw.polygon(self.screen, (0, 0, 0),
-                              [(center_x, center_y - 25), (center_x - 20, center_y + 20), (center_x + 20, center_y + 20)], 2)
-        
-        elif unit.unit_class == KnightClass.CAVALRY:
-            pygame.draw.ellipse(self.screen, player_color, (center_x - 25, center_y - 15, 50, 30))
-            pygame.draw.ellipse(self.screen, (0, 0, 0), (center_x - 25, center_y - 15, 50, 30), 2)
-        
-        elif unit.unit_class == KnightClass.MAGE:
-            pygame.draw.circle(self.screen, player_color, (center_x, center_y), 22)
-            pygame.draw.circle(self.screen, (0, 0, 0), (center_x, center_y), 22, 2)
+        strategy = self.unit_render_strategies.get(unit.unit_class)
+        if strategy:
+            strategy.render(self.screen, player_color, center_x, center_y)
     
     def _render_health_bar(self, unit, screen_x: float, screen_y: float):
         """Render health bar above unit."""


### PR DESCRIPTION
## Summary
- add `unit_render_strategies.py` defining `UnitRenderStrategy` classes
- map `KnightClass` to strategies inside `UnitRenderer`
- render units via strategy objects

## Testing
- `pytest -q` *(fails: 49 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68419e297da08323a0de1d032244dceb