### PR TITLE
Reduce attack AP cost if statements

### DIFF
--- a/game/behaviors/combat.py
+++ b/game/behaviors/combat.py
@@ -39,18 +39,11 @@ class AttackBehavior(Behavior):
         
     def get_ap_cost(self, unit=None, target=None, game_state=None) -> int:
         """Calculate AP cost for attack based on unit type, target terrain, and distance"""
-        base_cost = 3  # Base melee attack cost
-        
+        base_cost = 3  # Default
+
         if unit and hasattr(unit, 'unit_class'):
-            from game.entities.knight import KnightClass
-            
-            # Different costs by unit type
-            if unit.unit_class == KnightClass.WARRIOR:
-                base_cost = 4  # Warriors are methodical
-            elif unit.unit_class == KnightClass.CAVALRY:
-                base_cost = 3  # Cavalry are quick
-            elif unit.unit_class == KnightClass.MAGE:
-                base_cost = 2  # Magic is efficient
+            from game.combat_config import CombatConfig
+            base_cost = CombatConfig.get_attack_ap_cost(unit.unit_class.value)
         
         # Add terrain-based attack cost if target and game_state are provided
         if target and game_state and hasattr(game_state, 'terrain_map') and game_state.terrain_map:

--- a/game/combat_config.py
+++ b/game/combat_config.py
@@ -27,6 +27,19 @@ class CombatConfig:
     
     # Opportunity attack damage multiplier when enemy breaks away
     OPPORTUNITY_ATTACK_MULTIPLIER = 0.7  # 70% of normal attack damage
+
+    # Action point costs for standard attacks by unit class
+    ATTACK_AP_COSTS = {
+        "Warrior": 4,
+        "Archer": 2,
+        "Cavalry": 3,
+        "Mage": 2,
+    }
+
+    @classmethod
+    def get_attack_ap_cost(cls, unit_class_name: str) -> int:
+        """Get the base AP cost for a standard attack"""
+        return cls.ATTACK_AP_COSTS.get(unit_class_name, 3)
     
     @classmethod
     def is_heavy_unit(cls, unit_class_name: str) -> bool:

--- a/game/entities/unit.py
+++ b/game/entities/unit.py
@@ -557,16 +557,9 @@ class Unit:
         
     def consume_attack_ap(self):
         """Compatibility method - consume AP for attack"""
-        ap_cost = 3  # Default attack cost
-        if hasattr(self, 'unit_class'):
-            if self.unit_class == KnightClass.WARRIOR:
-                ap_cost = 4
-            elif self.unit_class == KnightClass.ARCHER:
-                ap_cost = 2
-            elif self.unit_class == KnightClass.CAVALRY:
-                ap_cost = 3
-            elif self.unit_class == KnightClass.MAGE:
-                ap_cost = 2
+        from game.combat_config import CombatConfig
+
+        ap_cost = CombatConfig.get_attack_ap_cost(self.unit_class.value)
                 
         if self.action_points >= ap_cost and not self.has_acted:
             self.action_points -= ap_cost


### PR DESCRIPTION
## Summary
- centralize base attack AP cost values in `CombatConfig`
- reuse new config in `AttackBehavior.get_ap_cost`
- reuse new config in `Unit.consume_attack_ap`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pygame')*

------
https://chatgpt.com/codex/tasks/task_e_68415b30e16483239dbffd5598a449de