### PR TITLE
Fix city placement Mercator calculations

### DIFF
--- a/tests/test_tile_terrain_generator.py
+++ b/tests/test_tile_terrain_generator.py
@@ -1,0 +1,31 @@
+import unittest
+from tools.tile_terrain_generator import convert_cities_to_hex_coordinates, GeographicBounds
+
+class TestTileTerrainGenerator(unittest.TestCase):
+    def test_city_coordinate_mapping_matches_tile_bounds(self):
+        """Cities should align with integer tile boundaries used for terrain."""
+        bounds = GeographicBounds(-8, -4, 42, 45)
+        cities = [
+            {
+                "name": "TestCity",
+                "latitude": 43.5,
+                "longitude": -6,
+                "city_type": "city",
+                "estimated_population": 1000,
+                "description": "",
+            }
+        ]
+        width = 30
+        height = 30
+        zoom = 8
+
+        game_cities, collisions, unique = convert_cities_to_hex_coordinates(
+            cities, bounds, width, height, zoom
+        )
+
+        self.assertEqual(game_cities["testcity"]["position"], [17, 15])
+        self.assertEqual(collisions, 0)
+        self.assertEqual(unique, 1)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tile_terrain_generator.py
+++ b/tools/tile_terrain_generator.py
@@ -268,11 +268,14 @@ def convert_cities_to_hex_coordinates(cities: List[Dict], bounds: GeographicBoun
         # Convert city lat/lon to tile coordinates at the same zoom level
         city_tile_x, city_tile_y = fetcher.deg2num_float(lat, lon, zoom)
         
-        # Get map bounds in tile coordinates using the same function
+        # Get map bounds in tile coordinates. Use integer tile numbers here
+        # because the tile image fetched by ``fetch_area_tiles`` is aligned to
+        # full tile boundaries.  Using the same integer bounds ensures that
+        # city positions line up perfectly with the generated terrain map.
         # IMPORTANT: In tile coordinates, Y increases from north to south!
         # So north latitude gives us the MIN tile Y, south latitude gives us MAX tile Y
-        west_x, south_y = fetcher.deg2num_float(bounds.south_lat, bounds.west_lon, zoom)
-        east_x, north_y = fetcher.deg2num_float(bounds.north_lat, bounds.east_lon, zoom)
+        west_x, south_y = fetcher.deg2num(bounds.south_lat, bounds.west_lon, zoom)
+        east_x, north_y = fetcher.deg2num(bounds.north_lat, bounds.east_lon, zoom)
         
         # Correct the min/max for the inverted Y axis
         min_tile_x = west_x


### PR DESCRIPTION
## Summary
- ensure tile bounds use integer Mercator tiles when mapping city coordinates
- add regression test for tile terrain generator city mapping

## Testing
- `pytest tests/test_tile_terrain_generator.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6844c4cbdcb8832383a7ebb7d25ae823